### PR TITLE
Error.pm - fix broken accessor

### DIFF
--- a/lib/Dancer2/Core/Error.pm
+++ b/lib/Dancer2/Core/Error.pm
@@ -295,7 +295,7 @@ sub _build_content {
 
 sub throw {
     my $self = shift;
-    $self->set_response(shift) if @_;
+    $self->response(shift) if @_;
 
     $self->response
         or croak "error has no response to throw at";


### PR DESCRIPTION
Dancer2::Core::Error::throw() attempts to set the response using set_response(), but response is 'rw', not 'rwp'.
